### PR TITLE
fix: update simulation configs to use v2 shed priority names

### DIFF
--- a/tests/fixtures/configs/battery_test_config.yaml
+++ b/tests/fixtures/configs/battery_test_config.yaml
@@ -14,7 +14,7 @@ circuit_templates:
       typical_power: 0.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     battery_behavior:
       enabled: true
       max_charge_power: -5000
@@ -39,7 +39,7 @@ circuit_templates:
       typical_power: 50.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
 circuits:
   - id: "battery_circuit"

--- a/tests/fixtures/configs/behavior_test_config.yaml
+++ b/tests/fixtures/configs/behavior_test_config.yaml
@@ -14,7 +14,7 @@ circuit_templates:
       typical_power: 2800.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       on_duration: 900    # 15 minutes on
       off_duration: 1800  # 30 minutes off
@@ -26,7 +26,7 @@ circuit_templates:
       typical_power: 40.0
       power_variation: 0.2
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [18, 19, 20, 21, 22]
@@ -38,7 +38,7 @@ circuit_templates:
       typical_power: 6000.0
       power_variation: 0.05
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     smart_behavior:
       max_power_reduction: 0.6  # Can reduce to 40% during grid stress
 
@@ -49,7 +49,7 @@ circuit_templates:
       typical_power: -4000.0
       power_variation: 0.3
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [10, 11, 12, 13, 14]  # Solar peak production
@@ -61,7 +61,7 @@ circuit_templates:
       typical_power: 75.0
       power_variation: 0.15
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
 circuits:
   - id: "main_hvac_cycling"

--- a/tests/fixtures/configs/simple_test_config.yaml
+++ b/tests/fixtures/configs/simple_test_config.yaml
@@ -14,7 +14,7 @@ circuit_templates:
       typical_power: 25.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   outlets:
     energy_profile:
@@ -23,7 +23,7 @@ circuit_templates:
       typical_power: 150.0
       power_variation: 0.3
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   hvac:
     energy_profile:
@@ -32,7 +32,7 @@ circuit_templates:
       typical_power: 2000.0
       power_variation: 0.15
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
   solar:
     energy_profile:
@@ -41,7 +41,7 @@ circuit_templates:
       typical_power: -2500.0
       power_variation: 0.2
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
 circuits:
   - id: "living_room_lights"

--- a/tests/fixtures/configs/simulation_config_32_circuit.yaml
+++ b/tests/fixtures/configs/simulation_config_32_circuit.yaml
@@ -16,7 +16,7 @@ circuit_templates:
       typical_power: 60.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # Exterior lighting with time-based patterns
   lighting:
@@ -26,7 +26,7 @@ circuit_templates:
       typical_power: 300.0
       power_variation: 0.05
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     time_of_day_profile:
       enabled: true
       peak_hours: [18, 19, 20, 21, 22]  # Evening hours
@@ -39,7 +39,7 @@ circuit_templates:
       typical_power: 2800.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     cycling_pattern:
       on_duration: 1200   # 20 minutes
       off_duration: 2400  # 40 minutes
@@ -52,7 +52,7 @@ circuit_templates:
       typical_power: 1800.0
       power_variation: 0.15
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
   # Refrigerator with compressor cycling
   refrigerator:
@@ -62,7 +62,7 @@ circuit_templates:
       typical_power: 120.0
       power_variation: 0.2
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     cycling_pattern:
       on_duration: 600    # 10 minutes
       off_duration: 1800  # 30 minutes
@@ -75,7 +75,7 @@ circuit_templates:
       typical_power: 7200.0  # Level 2 charging (240V @ 30A)
       power_variation: 0.05
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     device_type: "evse"  # Generates EVSE (SPAN Drive) snapshot
     smart_behavior:
       responds_to_grid: true
@@ -89,7 +89,7 @@ circuit_templates:
       typical_power: 800.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       on_duration: 7200   # 2 hours on
       off_duration: 14400 # 4 hours off
@@ -103,7 +103,7 @@ circuit_templates:
       power_variation: 0.3
       efficiency: 0.85  # 85% efficiency
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [11, 12, 13, 14, 15]  # Peak production 11 AM - 3 PM
@@ -135,7 +135,7 @@ circuit_templates:
       power_variation: 0.05  # Generators are very stable
       efficiency: 0.92  # 92% fuel efficiency
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # Battery storage - bidirectional
   battery_storage:
@@ -146,7 +146,7 @@ circuit_templates:
       power_variation: 0.02  # Very stable
       efficiency: 0.95  # 95% round-trip efficiency
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     battery_behavior:
       enabled: true
       charge_power: 3000.0
@@ -162,7 +162,7 @@ circuit_templates:
       power_variation: 0.5  # Very variable based on wind
       efficiency: 0.75  # 75% efficiency
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # General outlet circuits
   outlets:
@@ -172,7 +172,7 @@ circuit_templates:
       typical_power: 150.0
       power_variation: 0.4  # Very variable loads
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # Kitchen specific outlets (higher capacity)
   kitchen_outlets:
@@ -182,7 +182,7 @@ circuit_templates:
       typical_power: 300.0
       power_variation: 0.5  # Very variable - appliances
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # Heat pump with seasonal efficiency
   heat_pump:
@@ -192,7 +192,7 @@ circuit_templates:
       typical_power: 2800.0
       power_variation: 0.25  # Efficiency varies with temperature
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       on_duration: 900    # 15 minutes on
       off_duration: 1800  # 30 minutes off
@@ -205,7 +205,7 @@ circuit_templates:
       typical_power: 800.0
       power_variation: 0.3
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
 circuits:
   # Lighting circuits (tabs 1-6)
@@ -371,7 +371,7 @@ unmapped_tab_templates:
       power_variation: 0.2
       efficiency: 0.85
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [11, 12, 13, 14, 15]  # Peak production 11 AM - 3 PM
@@ -402,7 +402,7 @@ unmapped_tab_templates:
       power_variation: 0.2
       efficiency: 0.85
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [11, 12, 13, 14, 15]  # Peak production 11 AM - 3 PM

--- a/tests/fixtures/configs/simulation_config_40_circuit_with_battery.yaml
+++ b/tests/fixtures/configs/simulation_config_40_circuit_with_battery.yaml
@@ -15,7 +15,7 @@ circuit_templates:
       typical_power: 25.0
       power_variation: 0.15
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   outlets:
     energy_profile:
@@ -24,7 +24,7 @@ circuit_templates:
       typical_power: 150.0
       power_variation: 0.4
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   # EV charger (SPAN Drive) with smart grid response
   ev_charger:
@@ -34,7 +34,7 @@ circuit_templates:
       typical_power: 7200.0  # Level 2 charging (240V @ 30A)
       power_variation: 0.05
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     device_type: "evse"  # Generates EVSE (SPAN Drive) snapshot
     smart_behavior:
       responds_to_grid: true
@@ -47,7 +47,7 @@ circuit_templates:
       typical_power: 1500.0
       power_variation: 0.2
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     cycling_pattern:
       on_duration: 900    # 15 minutes
       off_duration: 1800  # 30 minutes
@@ -59,7 +59,7 @@ circuit_templates:
       typical_power: -4000.0
       power_variation: 0.4
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
 
   battery:
     energy_profile:
@@ -68,7 +68,7 @@ circuit_templates:
       typical_power: 0.0  # Neutral when idle
       power_variation: 0.1
     relay_behavior: "non_controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     battery_behavior:
       enabled: true
       charge_efficiency: 0.95  # 95% efficient charging
@@ -311,7 +311,7 @@ unmapped_tab_templates:
       typical_power: 150.0
       power_variation: 0.2
     relay_behavior: "non_controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
 simulation_params:
   enable_realistic_behaviors: true

--- a/tests/fixtures/configs/simulation_config_8_tab_workshop.yaml
+++ b/tests/fixtures/configs/simulation_config_8_tab_workshop.yaml
@@ -16,7 +16,7 @@ circuit_templates:
       typical_power: 45.0
       power_variation: 0.2
     relay_behavior: "controllable"
-    priority: "MUST_HAVE"
+    priority: "NEVER"
     time_of_day_profile:
       enabled: true
       peak_hours: [7, 8, 17, 18, 19, 20]
@@ -30,7 +30,7 @@ circuit_templates:
       typical_power: 2200.0
       power_variation: 0.4
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       enabled: true
       on_duration_minutes: 15
@@ -44,7 +44,7 @@ circuit_templates:
       typical_power: 400.0
       power_variation: 0.6
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       enabled: true
       on_duration_minutes: 8
@@ -58,7 +58,7 @@ circuit_templates:
       typical_power: 1500.0
       power_variation: 0.3
     relay_behavior: "controllable"
-    priority: "NICE_TO_HAVE"
+    priority: "SOC_THRESHOLD"
     time_of_day_profile:
       enabled: true
       peak_hours: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
@@ -102,7 +102,7 @@ unmapped_tab_templates:
       typical_power: 200.0
       power_variation: 0.3
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       enabled: true
       on_duration_minutes: 10
@@ -116,7 +116,7 @@ unmapped_tab_templates:
       typical_power: 400.0
       power_variation: 0.4
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       enabled: true
       on_duration_minutes: 15
@@ -130,7 +130,7 @@ unmapped_tab_templates:
       typical_power: 150.0
       power_variation: 0.2
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     time_of_day_profile:
       enabled: true
       peak_hours: [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
@@ -144,7 +144,7 @@ unmapped_tab_templates:
       typical_power: 300.0
       power_variation: 0.3
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
     cycling_pattern:
       enabled: true
       on_duration_minutes: 12

--- a/tests/fixtures/configs/validation_test_config.yaml
+++ b/tests/fixtures/configs/validation_test_config.yaml
@@ -14,7 +14,7 @@ circuit_templates:
       typical_power: 500.0
       power_variation: 0.1
     relay_behavior: "controllable"
-    priority: "NON_ESSENTIAL"
+    priority: "OFF_GRID"
 
   high_power_consumer:
     energy_profile:
@@ -23,7 +23,7 @@ circuit_templates:
       typical_power: 2500.0
       power_variation: 0.2
     relay_behavior: "controllable"
-    priority: "ESSENTIAL"
+    priority: "NEVER"
 
 circuits:
   - id: "test_circuit_1"


### PR DESCRIPTION
Replaced v1 priority names (MUST_HAVE, NON_ESSENTIAL, NICE_TO_HAVE, ESSENTIAL) with v2 names (NEVER, SOC_THRESHOLD, OFF_GRID) across all simulation YAML configs.