### PR TITLE
fix: normalize negative zero on idle circuit power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.4] - 03/2026
+
+### Fixed
+
+- **Negative zero on idle circuits** — Circuit power negation (`-raw_power_w`) produced IEEE 754 `-0.0` when the panel reported `0.0` for an idle circuit. The value is now normalized to positive zero after negation.
+
 ## [2.0.0] - 02/2026
 
 v2.0.0 is a ground-up rewrite. The REST/OpenAPI transport has been removed entirely in favor of MQTT/Homie — the SPAN Panel's native v2 protocol. This is a breaking change: all consumer code must be updated to use the new API surface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "span-panel-api"
-version = "2.2.2"
+version = "2.2.4"
 description = "A client library for SPAN Panel API"
 authors = [
     {name = "SpanPanel"}

--- a/src/span_panel_api/mqtt/homie.py
+++ b/src/span_panel_api/mqtt/homie.py
@@ -264,7 +264,7 @@ class HomieDeviceConsumer:
 
         # active-power is in watts; negate so positive = consumption
         raw_power_w = _parse_float(self._get_prop(node_id, "active-power"))
-        instant_power_w = -raw_power_w
+        instant_power_w = -raw_power_w or 0.0
 
         # Energy: exported-energy = consumption (panel exports TO circuit)
         consumed_wh = _parse_float(self._get_prop(node_id, "exported-energy"))


### PR DESCRIPTION
## Summary

- **Negative zero on idle circuits** — Circuit power negation (`-raw_power_w`) produced IEEE 754 `-0.0` when the panel reported `0.0` for an idle circuit, causing HA to display `-0W` instead of `0W`. The value is now normalized to positive zero after negation. (#185)
- Version bump to 2.2.4

## Test plan

- [ ] Verify idle circuits show `0W` not `-0W`
- [ ] CI passes