### PR TITLE
fix: replace assert in production code, fix broken bandit hook, bump …

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
 
   # Check for common security issues
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.3
+    rev: 1.9.4
     hooks:
       - id: bandit
         args: ['-c', 'pyproject.toml']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.1] - 04/2026
+
+### Fixed
+
+- **Replaced `assert` with `RuntimeError` in production code** — `HomieDeviceConsumer._rebuild_dirty_circuits()` used an `assert` to guard a cached-snapshot invariant, which would be silently stripped by `python -O`. Replaced with an explicit
+  `RuntimeError` raise.
+- **Fixed broken bandit pre-commit hook** — bandit was pinned to v1.8.3, which is incompatible with Python 3.14. It silently skipped all source files (20/20) and reported "Passed" with zero issues. Bumped to v1.9.4 which scans all files correctly.
+
 ## [2.5.0] - 03/2026
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "span-panel-api"
-version = "2.5.0"
+version = "2.5.1"
 description = "A client library for SPAN Panel API"
 authors = [
     {name = "SpanPanel"}

--- a/src/span_panel_api/__init__.py
+++ b/src/span_panel_api/__init__.py
@@ -4,6 +4,8 @@ A modern, type-safe Python client library for the SPAN Panel API,
 supporting MQTT/Homie (v2) transport.
 """
 
+from importlib.metadata import version as _pkg_version
+
 from .auth import (
     delete_fqdn,
     download_ca_cert,
@@ -54,7 +56,7 @@ from .protocol import (
     StreamingCapableProtocol,
 )
 
-__version__ = "2.5.0"
+__version__ = _pkg_version("span-panel-api")
 # fmt: off
 __all__ = [  # noqa: RUF022
     # Protocols

--- a/src/span_panel_api/mqtt/homie.py
+++ b/src/span_panel_api/mqtt/homie.py
@@ -136,7 +136,8 @@ class HomieDeviceConsumer:
 
     def _rebuild_dirty_circuits(self, dirty: frozenset[str]) -> SpanPanelSnapshot:
         """Partial rebuild — only rebuild circuits whose nodes are dirty."""
-        assert self._cached_snapshot is not None
+        if self._cached_snapshot is None:
+            raise RuntimeError("_rebuild_dirty_circuits called without a cached snapshot")
         cached = self._cached_snapshot
 
         feed_metadata = self._build_feed_metadata()

--- a/uv.lock
+++ b/uv.lock
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "span-panel-api"
-version = "2.5.0"
+version = "2.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
…to v2.5.1

Replace bare assert with RuntimeError in HomieDeviceConsumer._rebuild_dirty_circuits() and bump bandit pre-commit hook from 1.8.3 to 1.9.4 (1.8.3 silently skipped all files on Python 3.14).