### PR TITLE
ci: make workflows dispatchable and backport the release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main, develop ]
+  # Push and pull_request both arrive by webhook, so a dropped delivery leaves a
+  # commit with no run at all -- which reads the same as a commit that passed.
+  # Dispatch re-runs this against any ref on demand.
+  #
+  #   gh workflow run ci.yml --ref develop
+  workflow_dispatch:
 
 jobs:
   lint-and-test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,37 @@ name: Release
 on:
   release:
     types: [published]
+  # A `release: published` event reaches this workflow only through webhook
+  # delivery, and a dropped delivery is silent: the release exists, the tag
+  # exists, nothing publishes, and the run list looks the same as it did before.
+  # Dispatch goes through the API instead, so a release can always be driven to
+  # PyPI by hand.
+  #
+  #   gh workflow run release.yml --ref schema-1-v0.1.0b1
+  #
+  # Dispatch a tag, never a branch. The steps below read the distribution and
+  # version out of the tag name, so a branch ref carries neither; it falls
+  # through to the error case rather than being guessed at.
+  workflow_dispatch:
 
+# This repo publishes two distributions that version independently: the
+# bootstrap (span-panel-api) and each schema adapter (span-panel-api-schema-N).
+# One release publishes exactly one of them, chosen by the tag prefix:
+#
+#   v3.0.0b1            -> span-panel-api            (the historical convention)
+#   schema-0-v1.0.0b1   -> span-panel-api-schema-0
+#
+# The version lives in the distribution's own pyproject.toml and this workflow
+# only verifies the tag agrees. It deliberately does not rewrite the version at
+# release time: the adapter declares a floor on the bootstrap
+# (span-panel-api>=X), so the committed versions are load-bearing for resolution
+# and cannot be treated as placeholders that a release stamps over.
+#
+# Publishing uses PyPI trusted publishing, which is configured per project. A
+# distribution released here for the first time needs a pending publisher
+# created on PyPI beforehand (project name, this repo, workflow `release.yml`,
+# environment `release`); without it the publish step fails on an otherwise
+# correct build.
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -25,16 +55,63 @@ jobs:
       with:
         enable-cache: true
 
-    - name: Update version from tag
+    - name: Resolve the distribution from the tag
+      id: target
       run: |
-        # Extract version from git tag (remove 'v' prefix if present)
-        VERSION=${GITHUB_REF#refs/tags/}
-        VERSION=${VERSION#v}
-        echo "Setting version to $VERSION"
-        sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
+        TAG=${GITHUB_REF#refs/tags/}
+        case "$TAG" in
+          schema-*-v*)
+            SCHEMA=${TAG#schema-}
+            SCHEMA=${SCHEMA%%-v*}
+            PACKAGE="span-panel-api-schema-$SCHEMA"
+            MANIFEST="packages/schema-$SCHEMA/pyproject.toml"
+            VERSION=${TAG#schema-$SCHEMA-v}
+            ;;
+          v*)
+            PACKAGE="span-panel-api"
+            MANIFEST="pyproject.toml"
+            VERSION=${TAG#v}
+            ;;
+          *)
+            echo "::error::Tag '$TAG' names no distribution. Use 'vX.Y.Z' for the bootstrap or 'schema-N-vX.Y.Z' for an adapter."
+            exit 1
+            ;;
+        esac
+        if [ ! -f "$MANIFEST" ]; then
+          echo "::error::Tag '$TAG' resolves to '$MANIFEST', which does not exist."
+          exit 1
+        fi
+        echo "Tag '$TAG' releases $PACKAGE $VERSION from $MANIFEST"
+        echo "package=$PACKAGE" >> "$GITHUB_OUTPUT"
+        echo "manifest=$MANIFEST" >> "$GITHUB_OUTPUT"
+        echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+    - name: Verify the tag matches the committed version
+      run: |
+        DECLARED=$(python -c "import sys, tomllib; print(tomllib.load(open(sys.argv[1], 'rb'))['project']['version'])" "${{ steps.target.outputs.manifest }}")
+        if [ "$DECLARED" != "${{ steps.target.outputs.version }}" ]; then
+          echo "::error::${{ steps.target.outputs.manifest }} declares version '$DECLARED' but the tag says '${{ steps.target.outputs.version }}'. Commit the version bump before tagging."
+          exit 1
+        fi
+        echo "Version $DECLARED confirmed."
+
+    # Only the tagged distribution is built, so dist/ holds exactly what this
+    # release publishes and the publish step cannot pick up a sibling package.
     - name: Build package
-      run: uv build
+      run: uv build --package "${{ steps.target.outputs.package }}"
+
+    - name: Verify the wheel ships a py.typed marker
+      run: |
+        python -c "
+        import glob, sys, zipfile
+        wheels = glob.glob('dist/*.whl')
+        if not wheels:
+            sys.exit('::error::no wheel was built')
+        for wheel in wheels:
+            if not any(n.endswith('/py.typed') for n in zipfile.ZipFile(wheel).namelist()):
+                sys.exit(f'::error::{wheel} ships no py.typed marker; downstream type checking would resolve it as Any')
+            print(f'{wheel}: py.typed present')
+        "
 
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Why

Both workflows are reachable only through webhook delivery. During the GitHub Actions incident on 08-06 webhooks were throttled to ~15%, and the effect was silent rather than loud: a published release produced **no workflow run at all**, and the run list looked exactly as it had before. The release existed, the tag existed, nothing published, and nothing anywhere said so.

`workflow_dispatch` adds an API path to the same workflows. It only takes effect when the workflow file is on the default branch, which is why this has to land on `main` even though the release logic itself runs from tags.

## What changed

**`release.yml` is replaced with the version already running on `develop`.**

A `release` event runs the workflow file *from the tag*, so the copy on `main` has been dormant since the repo started publishing more than one distribution. It is not merely stale — it is wrong for any adapter tag. It derives the version by stripping a leading `v`:

```
VERSION=${GITHUB_REF#refs/tags/}   # schema-0-v1.0.0b1
VERSION=${VERSION#v}               # unchanged, no leading v
sed -i "s/^version = \".*\"/version = \"$VERSION\"/" pyproject.toml
```

For `schema-0-v1.0.0b1` that stamps the literal string `schema-0-v1.0.0b1` into the **root** `pyproject.toml` and publishes the wrong distribution. It has stayed harmless only because nothing reaches it. Adding a dispatch trigger without fixing it would have made that reachable.

**`ci.yml` gets the trigger only.** Its `develop` counterpart uses `uv sync --all-packages` and collects coverage from `packages/`, neither of which exists on this branch.

## Behaviour change worth knowing

This changes how a release from `main` is cut. The old file wrote the version into `pyproject.toml` from the tag, so a tag alone was sufficient. The new one verifies the committed version matches the tag and fails if it does not:

> the adapter declares a floor on the bootstrap (`span-panel-api>=X`), so the committed versions are load-bearing for resolution and cannot be treated as placeholders that a release stamps over

**Bump and commit the version before tagging.**

## Verified against this branch's layout

The backported file uses `uv build --package` and adds a `py.typed` gate, so both were checked against `main` as it stands rather than assumed:

| Check | Result |
| --- | --- |
| `uv build --package span-panel-api` with no `[tool.uv.workspace]` | builds `2.6.4` sdist + wheel — uv treats a lone project as its own workspace |
| `py.typed` marker in the resulting wheel | present, so the new gate passes |
| Tag `v*` resolution | `MANIFEST=pyproject.toml`, which exists here |
| Full test suite on this branch | 360 passed, 93.83% coverage |
| Both files parse; triggers resolve | `ci.yml` → push/pull_request/workflow_dispatch, `release.yml` → release/workflow_dispatch |

Dispatch a **tag**, never a branch — the workflow reads the distribution and version from the tag name, and a branch ref carries neither, so it exits on the existing error case instead of guessing.